### PR TITLE
fix the documentation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 `avail-apps` is a modified version of the [@polkadot/apps](https://github.com/polkadot-js/apps) repository for visualizing and interacting with the Avail network.
 
-Learn more about Avail at the Avail [product page](https://www.availproject.org) and [documentation](https://availproject.github.io/) websites.
+Learn more about Avail at the Avail [product page](https://www.availproject.org) and [documentation](https://docs.availproject.org/) websites.
 
 You can access a live version of the explorer for the Avail Testnet at https://goldberg.avail.tools/
 


### PR DESCRIPTION
The documentation link that in the Readme file does not work, the link (https://availproject.github.io) may be outdated or deleted. I have replaced the old link with a link to the documentation on your current website.

Old link is: https://availproject.github.io
New link is: https://docs.availproject.org