### PR TITLE
[codex] Update Avail ideal staked target to 50%

### DIFF
--- a/packages/apps-config/src/api/params/inflation.ts
+++ b/packages/apps-config/src/api/params/inflation.ts
@@ -28,7 +28,7 @@ const DEFAULT_PARAMS: InflationParams = {
 };
 
 const CERE_NETWORK_INFLATION_PARAMS = { ...DEFAULT_PARAMS, maxInflation: 0.05, minInflation: 0.0001, stakeTarget: 0.2 };
-const AVAIL_NETWORK_INFLATION_PARAMS = { ...DEFAULT_PARAMS, maxInflation: 0.05, minInflation: 0.01, stakeTarget: 0.75 };
+const AVAIL_NETWORK_INFLATION_PARAMS = { ...DEFAULT_PARAMS, maxInflation: 0.05, minInflation: 0.01, stakeTarget: 0.5 };
 
 const VARA_NETWORK_INFLATION_PARAMS = { ...DEFAULT_PARAMS, maxInflation: 0, minInflation: 0.0001, stakeTarget: 0.85 };
 


### PR DESCRIPTION
## Summary

Updates the Avail-specific staking inflation params so the staking overview uses a 50% ideal staked target instead of 75%.

## Impact

The staking tab now displays `ideal staked` as `50.0%` for Avail networks. Since the inflation estimate is calculated from the same `stakeTarget`, the displayed inflation estimate also updates accordingly.

## Validation

- Ran `git diff --check`
- Ran `yarn start` and confirmed webpack compiled successfully
- Verified locally at `http://localhost:3000/?rpc=wss://mainnet-rpc.avail.so/ws#/staking` that the staking overview shows `ideal staked 50.0%`
